### PR TITLE
don't strtolower values

### DIFF
--- a/pi.var.php
+++ b/pi.var.php
@@ -143,7 +143,7 @@ class Plugin_var extends Plugin
         if (!empty($this->content)) {
             $value = trim(Parse::template($this->content, $this->context));
         } else {
-            $value = $this->fetchParam(['is', 'value', 'val'], false);
+            $value = $this->fetchParam(['is', 'value', 'val'], false, null, false, false);
         }
 
         return $value;


### PR DESCRIPTION
Using this on builtwithstatamic.com. Since it forces lowercase, links to builders profiles are broken on gallery submissions if their username contains any capital letters. This change fixes that problem.
